### PR TITLE
[HCR-194] worker 배치 실행 기반 및 컨테이너/중앙 릴리즈 디스패치 구성

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+.git
+.github
+.gradle
+.idea
+build
+node_modules
+
+*.iml
+README.md
+!docker-entrypoint.sh

--- a/.github/workflows/dispatch-central-release.yml
+++ b/.github/workflows/dispatch-central-release.yml
@@ -1,0 +1,28 @@
+name: dispatch-central-release
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch to infra central orchestrator
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.CENTRAL_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'one-year-gap',
+              repo: 'infra',
+              event_type: 'release-request',
+              client_payload: {
+                source_repo: context.repo.owner + '/' + context.repo.repo,
+                source_sha: context.sha,
+                source_ref: context.ref
+              }
+            });

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM gradle:8-jdk17 AS builder
+WORKDIR /app
+
+COPY gradle ./gradle
+COPY gradlew build.gradle settings.gradle ./
+RUN chmod +x ./gradlew
+
+COPY src ./src
+RUN ./gradlew --no-daemon clean bootJar
+
+FROM eclipse-temurin:17-jre
+WORKDIR /app
+
+COPY --from=builder /app/build/libs/*.jar /app/app.jar
+COPY docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
+
+EXPOSE 8080
+ENV SPRING_PROFILES_ACTIVE=container
+ENTRYPOINT ["/app/docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+set -eu
+
+# Accept common DB env styles used by api-server and infra.
+db_url="${SPRING_DATASOURCE_URL:-${DATABASE_URL:-${DB_URL:-}}}"
+db_user="${SPRING_DATASOURCE_USERNAME:-${DATABASE_USERNAME:-${DB_USERNAME:-${DB_USER:-${POSTGRES_USER:-${RDS_USERNAME:-}}}}}}"
+db_pass="${SPRING_DATASOURCE_PASSWORD:-${DATABASE_PASSWORD:-${DB_PASSWORD:-${POSTGRES_PASSWORD:-${RDS_PASSWORD:-}}}}}"
+
+db_host="${DB_HOST:-${POSTGRES_HOST:-${RDS_HOSTNAME:-}}}"
+db_port="${DB_PORT:-${POSTGRES_PORT:-${RDS_PORT:-5432}}}"
+db_name="${DB_NAME:-${POSTGRES_DB:-${RDS_DB_NAME:-holliverse}}}"
+
+if [ -z "${db_url}" ] && [ -n "${db_host}" ]; then
+  if [ "${db_host}" = "127.0.0.1" ] || [ "${db_host}" = "localhost" ]; then
+    db_host="host.docker.internal"
+  fi
+  db_url="jdbc:postgresql://${db_host}:${db_port}/${db_name}"
+fi
+
+case "${db_url}" in
+  postgres://*|postgresql://*)
+    db_url="jdbc:${db_url}"
+    ;;
+esac
+
+# In containers, localhost points to this container itself.
+case "${db_url}" in
+  jdbc:postgresql://127.0.0.1:*|jdbc:postgresql://localhost:*)
+    db_url="$(echo "${db_url}" | sed -E 's#^jdbc:postgresql://(127\.0\.0\.1|localhost):#jdbc:postgresql://host.docker.internal:#')"
+    ;;
+esac
+
+db_url="${db_url:-jdbc:postgresql://host.docker.internal:5432/holliverse}"
+db_user="${db_user:-postgres}"
+db_pass="${db_pass:-postgres}"
+
+export SPRING_DATASOURCE_URL="${db_url}"
+export SPRING_DATASOURCE_USERNAME="${db_user}"
+export SPRING_DATASOURCE_PASSWORD="${db_pass}"
+
+echo "[entrypoint] SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-container}"
+echo "[entrypoint] SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}"
+echo "[entrypoint] SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}"
+
+exec java -jar /app/app.jar

--- a/src/main/java/site/holliverse/worker/BatchRunner.java
+++ b/src/main/java/site/holliverse/worker/BatchRunner.java
@@ -1,0 +1,58 @@
+package site.holliverse.worker;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.config.BatchJobConfiguration;
+import site.holliverse.worker.config.TimeProperties;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+
+@Component
+@Slf4j
+public class BatchRunner implements CommandLineRunner {
+    private final ApplicationContext applicationContext;
+    private final JobLauncher jobLauncher;
+    private final BatchJobConfiguration configuration;
+    private final TimeProperties timeProperties;
+    private final boolean exitOnComplete;
+    private final boolean addRunId;
+    private final ZoneId zoneId;
+    private final DateTimeFormatter formatter;
+
+    public BatchRunner(
+            ApplicationContext applicationContext,
+            JobLauncher jobLauncher,
+            BatchJobConfiguration configuration,
+            TimeProperties timeProperties,
+            @Value("${BATCH_EXIT_ON_COMPLETE:true}") boolean exitOnComplete,
+            @Value("${BATCH_ADD_RUN_ID:false}") boolean addRunId
+    ) {
+        this.applicationContext = applicationContext;
+        this.jobLauncher = jobLauncher;
+        this.configuration = configuration;
+        this.timeProperties = timeProperties;
+        this.exitOnComplete = exitOnComplete;
+        this.addRunId = addRunId;
+
+        this.zoneId = ZoneId.of(timeProperties.zone());
+        this.formatter = DateTimeFormatter.ofPattern(timeProperties.format());
+    }
+
+    @Override
+    public void run(String... args) throws Exception {
+        String jobName = configuration.getJobName();
+        log.info("Resolved spring.batch.job.name='{}'", configuration.getJobName());
+
+        switch (jobName) {
+            case "testJob":
+                log.info("TestJob");
+                break;
+            default:
+                throw new IllegalArgumentException("unknown job name!");
+        }
+    }
+}

--- a/src/main/java/site/holliverse/worker/WorkerApplication.java
+++ b/src/main/java/site/holliverse/worker/WorkerApplication.java
@@ -2,11 +2,13 @@ package site.holliverse.worker;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
 @SpringBootApplication
+@ConfigurationPropertiesScan
 public class WorkerApplication {
 
     public static void main(String[] args) {
-        SpringApplication.run(WorkerApplication.class, args);
+        SpringApplication.exit(SpringApplication.run(WorkerApplication.class,args));
     }
 }

--- a/src/main/java/site/holliverse/worker/config/BatchJobConfiguration.java
+++ b/src/main/java/site/holliverse/worker/config/BatchJobConfiguration.java
@@ -1,0 +1,45 @@
+package site.holliverse.worker.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Configurable;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Instant;
+
+@Configuration
+@Getter
+@Slf4j
+@RequiredArgsConstructor
+public class BatchJobConfiguration {
+    @Value("${spring.batch.job.name:}")
+    private String jobName;
+
+    @Value("${spring.batch.testJob.startTime:}")
+    private String testJobStartTime;
+
+    private final ObjectMapper mapper;
+
+    @PostConstruct
+    public void logConfiguration(){
+        log.info("========= Batch Configuration =========");
+        log.info("jobName: '{}'", jobName);
+        log.info("job1StartTime: '{}'", testJobStartTime);
+        log.info("=======================================");
+    }
+
+    /**
+     * testJob -> Instant parsing
+     */
+    public Instant getTestJobTimeAsInstant(){
+        if (testJobStartTime ==null || testJobStartTime.isBlank()){
+            throw new IllegalArgumentException("batch.testJob.startTime 값이 입력되지 않았습니다.");
+        }
+
+        return Instant.parse(testJobStartTime);
+    }
+}

--- a/src/main/java/site/holliverse/worker/config/TimeProperties.java
+++ b/src/main/java/site/holliverse/worker/config/TimeProperties.java
@@ -1,0 +1,15 @@
+package site.holliverse.worker.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@ConfigurationProperties(prefix = "spring.time")
+public record TimeProperties(
+        String format,
+        String zone
+) {
+    public TimeProperties {
+        if (format == null || format.isBlank()) format = "yyyy-MM-dd HH:mm:ss";
+        if (zone == null || zone.isBlank()) zone = "Asia/Seoul";
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,4 @@
+spring:
+  batch:
+    jdbc:
+      initialize-schema: always

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,18 +1,55 @@
 spring:
   application:
     name: worker
+  profiles:
+    default: local
 
+  #AWS Secret Manager
+  config:
+    import: "optional:aws-secretsmanager:holliverse/api-server/runtime"
+  cloud:
+    aws:
+      region:
+        static: ap-northeast-2
+      stack:
+        auto: false
+
+  #Database setting
   datasource:
     url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://127.0.0.1:5432/holliverse}
     username: ${SPRING_DATASOURCE_USERNAME:postgres}
     password: ${SPRING_DATASOURCE_PASSWORD:postgres}
     driver-class-name: org.postgresql.Driver
-
+    hikari:
+      maximum-pool-size: ${DB_POOL_MAX:20}
+      minimum-idle: ${DB_POOL_MIN:5}
+      connection-timeout: 3000
+      validation-timeout: 1000
   batch:
     job:
       enabled: false
     jdbc:
-      initialize-schema: ${SPRING_BATCH_INIT_SCHEMA:always}
+      initialize-schema: never
+
+  #Time
+  time:
+    format: "yyyy-MM-dd HH:mm:ss"
+    zone: "Asia/Seoul"
 
 server:
-  port: ${SERVER_PORT:8081}
+  port: 8080
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: prometheus,health,info
+  endpoint:
+    prometheus:
+      enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    distribution:
+      percentiles-histogram:
+        mongo.command.duration: true


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->
  - 배치 워커 실행 진입점(CommandLineRunner)과 잡 설정 구조를 추가
  - `spring.time` 기반 시간 포맷/타임존 프로퍼티를 도입
  - 워커 컨테이너 실행을 위한 Dockerfile/entrypoint/.dockerignore를 추가
  - `main` 브랜치 push 시 infra 저장소로 중앙 릴리즈 디스패치를 보내는 GitHub Actions 워크플로우를 추가


<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->

  | 구분 | 파일 | 변경 내용 |
  |---|---|---|
  | 배치 실행 구조 | `src/main/java/site/holliverse/worker/BatchRunner.java` | `spring.batch.job.name` 기준으로 잡 분기 실행 로직 골격 추가 |
  | 앱 부트스트랩 | `src/main/java/site/holliverse/worker/WorkerApplication.java` | `@ConfigurationPropertiesScan` 추가, 앱 실행 후 종료(`SpringApplication.exit`) 처리 |
  | 배치 설정 | `src/main/java/site/holliverse/worker/config/BatchJobConfiguration.java` | 잡 이름/시작시간 설정값 로깅 및 `Instant` 파싱 메서드 추가 |
  | 시간 설정 | `src/main/java/site/holliverse/worker/config/TimeProperties.java` | `spring.time.format`, `spring.time.zone` 프로퍼티 바인딩 및 기본값 설정 |
  | 런타임 설정 | `src/main/resources/application.yaml` | 기본 프로필(local), AWS Secrets Manager import, DB/Hikari, 배치 스키마 init, 포트/메트릭 설정 정리 |
  | 로컬 설정 | `src/main/resources/application-local.yml` | 로컬 환경에서 배치 스키마 자동 초기화(`always`) 추가 |
  | 컨테이너 빌드 | `Dockerfile`, `.dockerignore` | 멀티스테이지 빌드 및 런타임 이미지 구성 |
  | 컨테이너 실행 | `docker-entrypoint.sh` | 다양한 DB 환경변수 호환, JDBC URL 보정, Spring datasource 환경변수 주입 |
  | CI/CD | `.github/workflows/dispatch-central-release.yml` | `main` push 시 `one-year-gap/infra`에 `release-request` repository_dispatch 전송 |


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-194

<br/>

## #️⃣관련 이슈

- closes #6 
