### PR TITLE
[HCR-253] 배치 리스너 기반 구조화 로깅 적용

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 .gradle-home/
+logs/*
+!logs/.gitkeep

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation group: 'com.github.f4b6a3', name: 'tsid-creator', version: '5.2.6'
 	implementation 'org.springframework.kafka:spring-kafka'
     implementation 'software.amazon.msk:aws-msk-iam-auth:2.2.0'
+	implementation 'net.logstash.logback:logstash-logback-encoder:7.4'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.micrometer:micrometer-registry-prometheus'

--- a/src/main/java/site/holliverse/worker/BatchRunner.java
+++ b/src/main/java/site/holliverse/worker/BatchRunner.java
@@ -73,9 +73,6 @@ public class BatchRunner implements CommandLineRunner {
         BatchStatus status = execution.getStatus();
         String exitCode = execution.getExitStatus().getExitCode();
 
-        log.info("jobName={}, status={}, exitCode={}", jobName, status, exitCode);
-
-
         //COMPLETED 아니면 예외
         boolean completed = status == BatchStatus.COMPLETED
                             && ExitStatus.COMPLETED.getExitCode().equals(exitCode);
@@ -85,7 +82,5 @@ public class BatchRunner implements CommandLineRunner {
                     "Batch verification failed: status=" + status + ", exitCode=" + exitCode
             );
         }
-
-        log.info("Batch verification passed.");
     }
 }

--- a/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobConfigEnum.java
+++ b/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobConfigEnum.java
@@ -1,0 +1,14 @@
+package site.holliverse.worker.batch.common.listener;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BatchJobConfigEnum {
+    KEY_JOB_NAME("jobName"),
+    KEY_JOB_INSTANCE("jobInstanceId"),
+    KEY_STEP_NAME("stepName");
+
+    private final String key;
+}

--- a/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobExecutionListener.java
+++ b/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobExecutionListener.java
@@ -1,0 +1,28 @@
+package site.holliverse.worker.batch.common.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.JobExecutionListener;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.global.logging.BatchLogContext;
+
+@Component
+@Slf4j
+public class BatchJobExecutionListener implements JobExecutionListener {
+
+    @Override
+    public void beforeJob(JobExecution jobExecution) {
+        BatchLogContext.putJob(jobExecution);
+        log.info("job started");
+    }
+
+    @Override
+    public void afterJob(JobExecution jobExecution) {
+        try {
+            log.info("job finished. status={}, exitCode={}",
+                    jobExecution.getStatus(), jobExecution.getExitStatus().getExitCode());
+        } finally {
+            BatchLogContext.clear();
+        }
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobExecutionListener.java
+++ b/src/main/java/site/holliverse/worker/batch/common/listener/BatchJobExecutionListener.java
@@ -13,7 +13,6 @@ public class BatchJobExecutionListener implements JobExecutionListener {
     @Override
     public void beforeJob(JobExecution jobExecution) {
         BatchLogContext.putJob(jobExecution);
-        log.info("job started");
     }
 
     @Override

--- a/src/main/java/site/holliverse/worker/batch/common/listener/BatchStepExecutionListener.java
+++ b/src/main/java/site/holliverse/worker/batch/common/listener/BatchStepExecutionListener.java
@@ -1,0 +1,33 @@
+package site.holliverse.worker.batch.common.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.ExitStatus;
+import org.springframework.batch.core.StepExecution;
+import org.springframework.batch.core.StepExecutionListener;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.global.logging.BatchLogContext;
+
+@Component
+@Slf4j
+public class BatchStepExecutionListener implements StepExecutionListener {
+
+    @Override
+    public void beforeStep(StepExecution stepExecution) {
+        BatchLogContext.putStep(stepExecution);
+        log.info("step started");
+    }
+
+    @Override
+    public ExitStatus afterStep(StepExecution stepExecution) {
+        try {
+            log.info("step finished. status={}, readCount={}, writeCount={}, skipCount={}",
+                    stepExecution.getStatus(),
+                    stepExecution.getReadCount(),
+                    stepExecution.getWriteCount(),
+                    stepExecution.getSkipCount());
+            return stepExecution.getExitStatus();
+        } finally {
+            BatchLogContext.removeStep();
+        }
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/common/listener/BatchStepExecutionListener.java
+++ b/src/main/java/site/holliverse/worker/batch/common/listener/BatchStepExecutionListener.java
@@ -14,7 +14,6 @@ public class BatchStepExecutionListener implements StepExecutionListener {
     @Override
     public void beforeStep(StepExecution stepExecution) {
         BatchLogContext.putStep(stepExecution);
-        log.info("step started");
     }
 
     @Override

--- a/src/main/java/site/holliverse/worker/batch/consultation/job/ConsultationKeywordAnalysisJobConfig.java
+++ b/src/main/java/site/holliverse/worker/batch/consultation/job/ConsultationKeywordAnalysisJobConfig.java
@@ -10,6 +10,8 @@ import org.springframework.batch.core.step.builder.StepBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.transaction.PlatformTransactionManager;
+import site.holliverse.worker.batch.common.listener.BatchJobExecutionListener;
+import site.holliverse.worker.batch.common.listener.BatchStepExecutionListener;
 import site.holliverse.worker.batch.consultation.step.ClaimStepTasklet;
 import site.holliverse.worker.batch.consultation.step.DispatchTasklet;
 
@@ -19,12 +21,15 @@ public class ConsultationKeywordAnalysisJobConfig {
     private static final String JOB_NAME = "consultationKeywordAnalysisJob";
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
+    private final BatchJobExecutionListener batchJobExecutionListener;
+    private final BatchStepExecutionListener batchStepExecutionListener;
     private final ClaimStepTasklet claimStepTasklet;
     private final DispatchTasklet dispatchTasklet;
 
     @Bean("consultation-keyword-analysis-job")
     public Job consultationKeywordAnalysisJob(){
         return new JobBuilder(JOB_NAME,jobRepository)
+                .listener(batchJobExecutionListener)
                 .start(claimStep())
                 .on(ClaimStepTasklet.EXIT_NO_CLAIMED_CASES).end()
                 .from(claimStep()).on(ExitStatus.COMPLETED.getExitCode()).to(dispatchStep())
@@ -38,6 +43,7 @@ public class ConsultationKeywordAnalysisJobConfig {
     @Bean
     public Step claimStep(){
         return new StepBuilder("claimStep",jobRepository)
+                .listener(batchStepExecutionListener)
                 .tasklet(claimStepTasklet,transactionManager)
                 .build();
     }
@@ -45,6 +51,7 @@ public class ConsultationKeywordAnalysisJobConfig {
     @Bean
     public Step dispatchStep(){
         return new StepBuilder("dispatchStep",jobRepository)
+                .listener(batchStepExecutionListener)
                 .tasklet(dispatchTasklet,transactionManager)
                 .build();
     }

--- a/src/main/java/site/holliverse/worker/config/TestJobConfig.java
+++ b/src/main/java/site/holliverse/worker/config/TestJobConfig.java
@@ -13,6 +13,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.transaction.PlatformTransactionManager;
+import site.holliverse.worker.batch.common.listener.BatchJobExecutionListener;
+import site.holliverse.worker.batch.common.listener.BatchStepExecutionListener;
 
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -28,6 +30,8 @@ import java.util.Map;
 public class TestJobConfig {
     private final JobRepository jobRepository;
     private final PlatformTransactionManager transactionManager;
+    private final BatchJobExecutionListener batchJobExecutionListener;
+    private final BatchStepExecutionListener batchStepExecutionListener;
     private final JdbcTemplate jdbcTemplate;
     private final ObjectMapper mapper;
 
@@ -35,7 +39,9 @@ public class TestJobConfig {
     public Job testJob() {
         //RunTime 검증을 위한 testJob 구성
         return new JobBuilder("testJob", jobRepository)
+                .listener(batchJobExecutionListener)
                 .start(new StepBuilder("testStep", jobRepository)
+                        .listener(batchStepExecutionListener)
                         .tasklet((contribution, chunkContext) -> {
                             //1. DB 연결 검증
                             Integer ping = jdbcTemplate.queryForObject("select 1", Integer.class);

--- a/src/main/java/site/holliverse/worker/config/TestJobConfig.java
+++ b/src/main/java/site/holliverse/worker/config/TestJobConfig.java
@@ -70,8 +70,6 @@ public class TestJobConfig {
                                     StandardOpenOption.CREATE,
                                     StandardOpenOption.TRUNCATE_EXISTING
                             );
-
-                            log.info("verification marker written: {}", marker);
                             contribution.setExitStatus(ExitStatus.COMPLETED);
 
                             return RepeatStatus.FINISHED;

--- a/src/main/java/site/holliverse/worker/global/logging/BatchLogContext.java
+++ b/src/main/java/site/holliverse/worker/global/logging/BatchLogContext.java
@@ -1,0 +1,59 @@
+package site.holliverse.worker.global.logging;
+
+import org.slf4j.MDC;
+import org.springframework.batch.core.JobExecution;
+import org.springframework.batch.core.StepExecution;
+
+import static site.holliverse.worker.batch.common.listener.BatchJobConfigEnum.*;
+
+/**
+ * Spring Batch 실행 컨텍스트를 MDC에 세팅/해제
+ */
+public final class BatchLogContext {
+
+
+    private BatchLogContext() {
+    }
+
+    /**
+     * Job 시작 시 호출
+     */
+    public static void putJob(JobExecution jobExecution) {
+        String jobName = jobExecution.getJobInstance().getJobName();
+        Long jobInstanceId = jobExecution.getJobInstance().getInstanceId();
+
+        put(KEY_JOB_NAME.getKey(), jobName);
+        put(KEY_JOB_INSTANCE.getKey(), jobInstanceId == null ? null : String.valueOf(jobInstanceId));
+    }
+
+    /**
+     * Step 시작 시 호출
+     */
+    public static void putStep(StepExecution stepExecution) {
+        put(KEY_STEP_NAME.getKey(), stepExecution.getStepName());
+    }
+
+    /**
+     * Step 종료 시 호출
+     */
+    public static void removeStep() {
+        MDC.remove(KEY_STEP_NAME.getKey());
+    }
+
+    /**
+     * Job 종료 시 호출
+     */
+    public static void clear() {
+        MDC.remove(KEY_JOB_NAME.getKey());
+        MDC.remove(KEY_JOB_INSTANCE.getKey());
+        MDC.remove(KEY_STEP_NAME.getKey());
+    }
+
+    private static void put(String key, String value) {
+        if (value == null || value.isBlank()) {
+            MDC.remove(key);
+            return;
+        }
+        MDC.put(key, value);
+    }
+}

--- a/src/main/resources/application.worker.yml
+++ b/src/main/resources/application.worker.yml
@@ -4,6 +4,8 @@
 worker:
   id:
     tsid-node: ${TSID_NODE:0}
+  logging:
+    json-file-path: ${WORKER_LOG_JSON_FILE_PATH:./logs/worker.json}
   kafka:
     topic:
       analysis-request: ${ANALYSIS_REQUEST_TOPIC:analysis.request.v1}
@@ -19,3 +21,14 @@ worker:
       claim-lease-sec: ${ANALYSIS_CLAIM_LEASE_TTL:1800}
       #alias dictionary
       alias-dictionary-path: ${ANALYSIS_ALIAS_DICTIONARY_PATH:/efs/analysis/alias-dictionary.json}
+
+########################################
+# Spring Batch setting
+########################################
+spring:
+  batch:
+    job:
+      enabled: false
+      name: ${SPRING_BATCH_JOB_NAME:testJob}
+    jdbc:
+      initialize-schema: never

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -29,12 +29,6 @@ spring:
       minimum-idle: ${DB_POOL_MIN:5}
       connection-timeout: 3000
       validation-timeout: 1000
-  batch:
-    job:
-      enabled: false
-      name: ${SPRING_BATCH_JOB_NAME:testJob}
-    jdbc:
-      initialize-schema: never
 
   #Time
   time:
@@ -48,12 +42,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: prometheus,health,info
+        include: prometheus,health,info,metrics
   endpoint:
     prometheus:
       enabled: true
   metrics:
     tags:
+      app: worker
+      profile: ${SPRING_PROFILES_ACTIVE:unknown}
       application: ${spring.application.name}
     distribution:
       percentiles-histogram:
@@ -61,7 +57,7 @@ management:
 
 logging:
   level:
-    root: WARN
+    root: INFO
     site.holliverse.worker: INFO
     org.springframework.batch: INFO
     org.springframework.kafka: WARN

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <springProperty scope="context"
+                    name="jsonLogPath"
+                    source="worker.logging.json-file-path"
+                    defaultValue="./logs/worker.json"/>
+
+    <!-- ================================================================
+         local 프로파일
+         ================================================================ -->
+    <springProfile name="local">
+        <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder>
+                <pattern>%d{HH:mm:ss.SSS} %highlight(%-5level) %cyan(%logger{36}) [%X{jobName:-}/%X{stepName:-}] - %msg%n</pattern>
+            </encoder>
+        </appender>
+        <appender name="FILE_JSON" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${jsonLogPath}</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${jsonLogPath}.%d{yyyy-MM-dd}.%i.gz</fileNamePattern>
+                <maxFileSize>50MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>500MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <customFields>{"application":"worker","environment":"local"}</customFields>
+                <mdcKeyFieldName>jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+                <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>
+                <timeZone>UTC</timeZone>
+            </encoder>
+        </appender>
+
+        <root level="WARN">
+            <appender-ref ref="CONSOLE"/>
+            <appender-ref ref="FILE_JSON"/>
+        </root>
+        <logger name="site.holliverse.worker" level="INFO"/>
+        <logger name="org.springframework.batch" level="INFO"/>
+        <logger name="org.springframework.kafka" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+    <!-- ================================================================
+         non-local 프로파일
+         ================================================================ -->
+    <springProfile name="!local">
+        <appender name="CONSOLE_JSON" class="ch.qos.logback.core.ConsoleAppender">
+            <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+                <!-- Loki stream label로 사용할 고정 필드 -->
+                <customFields>{"application":"worker"}</customFields>
+
+                <!-- MDC 키를 최상위 JSON 필드로 승격 (label 쿼리 용이성) -->
+                <mdcKeyFieldName>jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+
+                <!-- 타임스탬프 필드명 Loki 권장 형식 -->
+                <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>
+                <timeZone>KST</timeZone>
+
+                <!-- 불필요한 필드 제거 -->
+                <excludeMdcKeyName>_unused</excludeMdcKeyName>
+            </encoder>
+        </appender>
+
+        <root level="WARN">
+            <appender-ref ref="CONSOLE_JSON"/>
+        </root>
+        <logger name="site.holliverse.worker" level="INFO"/>
+        <logger name="org.springframework.batch" level="INFO"/>
+        <logger name="org.springframework.kafka" level="WARN"/>
+        <logger name="org.apache.kafka" level="WARN"/>
+    </springProfile>
+
+</configuration>


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->

- Spring Batch `Job/Step Listener`를 전역으로 적용해 실행 컨텍스트를 MDC에 주입하도록 구성
- `BatchLogContext`/`BatchJobConfigEnum`을 통해 `jobName`, `jobInstanceId`, `stepName`를 로그 필드로 일관되게 관리하도록 정리
- Logback JSON 로깅(`logstash-logback-encoder`)을 추가하고, 배치/메트릭/로그 설정을 운영 관점으로 정리
- 배치 실행 로그 중복 출력을 줄여 로그 가독성을 개선



<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->


| 구분 | 파일 | 변경 내용 |
|---|---|---|
| 리스너/MDC | `src/main/java/site/holliverse/worker/batch/common/listener/BatchJobExecutionListener.java` | Job 시작/종료 시 MDC 컨텍스트 주입/정리 |
| 리스너/MDC | `src/main/java/site/holliverse/worker/batch/common/listener/BatchStepExecutionListener.java` | Step 시작/종료 시 MDC 컨텍스트 주입/정리 |
| 리스너/MDC | `src/main/java/site/holliverse/worker/global/logging/BatchLogContext.java` | MDC put/remove/clear 유틸 구현 |
| 리스너/MDC | `src/main/java/site/holliverse/worker/batch/common/listener/BatchJobConfigEnum.java` | MDC 키 상수(enum) 정리 |
| 잡 설정 | `src/main/java/site/holliverse/worker/batch/consultation/job/ConsultationKeywordAnalysisJobConfig.java` | consultation job/step에 listener 연결 |
| 잡 설정 | `src/main/java/site/holliverse/worker/config/TestJobConfig.java` | testJob/testStep에 listener 연결 |
| 로깅 설정 | `src/main/resources/logback-spring.xml` | local/non-local 프로파일별 콘솔/JSON 로그 설정 |
| 앱 설정 | `src/main/resources/application.worker.yml` | worker logging 경로, spring batch 설정 정리 |
| 앱 설정 | `src/main/resources/application.yaml` | batch 설정 위치 정리, metrics/log level 조정 |
| 빌드/기타 | `build.gradle`, `.gitignore`, `src/main/java/site/holliverse/worker/BatchRunner.java` | logstash encoder 의존성 추가, logs ignore, 불필요 로그 제거 |


<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-253

<br/>

## #️⃣관련 이슈

- closes #19 
