### PR TITLE
[HCR-264] logback key 수정

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,4 +42,4 @@ echo "[entrypoint] SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-container}"
 echo "[entrypoint] SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}"
 echo "[entrypoint] SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}"
 
-exec java -jar /app/app.jar
+exec java -jar /app/app.jar "$@"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -52,9 +52,9 @@
                 <customFields>{"application":"worker"}</customFields>
 
                 <!-- MDC 키를 최상위 JSON 필드로 승격 (label 쿼리 용이성) -->
-                <mdcKeyFieldName>jobName</mdcKeyFieldName>
-                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
-                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobName=jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId=jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName=stepName</mdcKeyFieldName>
 
                 <!-- 타임스탬프 필드명 Loki 권장 형식 -->
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,9 +24,9 @@
             </rollingPolicy>
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <customFields>{"application":"worker","environment":"local"}</customFields>
-                <mdcKeyFieldName>jobName</mdcKeyFieldName>
-                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
-                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobName=jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId=jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName=stepName</mdcKeyFieldName>
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>
                 <timeZone>UTC</timeZone>
             </encoder>


### PR DESCRIPTION
## 📝작업 내용
- `logback-spring.xml`의 `mdcKeyFieldName` 설정을 `key=value` 형식으로 수정해 MDC 필드가 JSON 로그에 올바르게 매핑되도록 변경
- `docker-entrypoint.sh`에서 `java -jar /app/app.jar "$@"` 형태로 실행하도록 수정해 컨테이너 실행 시 추가 인자가 애플리케이션으로 전달되도록 보완

<br/>

## 👀변경 사항
- JSON 로그에 `jobName`, `jobInstanceId`, `stepName` MDC 필드가 누락되거나 기대와 다르게 출력되던 문제를 수정했습니다.
- 컨테이너 실행 시 전달한 추가 JVM/애플리케이션 인자가 무시되던 문제를 수정했습니다.
- 운영 환경에서 로그 수집과 배치 실행 옵션 전달의 정합성이 개선됩니다.

<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-264

<br/>

## #️⃣관련 이슈

- closes #24 
