### PR TITLE
[HSC-265] v0.0.9

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -42,4 +42,4 @@ echo "[entrypoint] SPRING_PROFILES_ACTIVE=${SPRING_PROFILES_ACTIVE:-container}"
 echo "[entrypoint] SPRING_DATASOURCE_URL=${SPRING_DATASOURCE_URL}"
 echo "[entrypoint] SPRING_DATASOURCE_USERNAME=${SPRING_DATASOURCE_USERNAME}"
 
-exec java -jar /app/app.jar
+exec java -jar /app/app.jar "$@"

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -52,9 +52,9 @@
                 <customFields>{"application":"worker"}</customFields>
 
                 <!-- MDC 키를 최상위 JSON 필드로 승격 (label 쿼리 용이성) -->
-                <mdcKeyFieldName>jobName</mdcKeyFieldName>
-                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
-                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobName=jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId=jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName=stepName</mdcKeyFieldName>
 
                 <!-- 타임스탬프 필드명 Loki 권장 형식 -->
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -24,9 +24,9 @@
             </rollingPolicy>
             <encoder class="net.logstash.logback.encoder.LogstashEncoder">
                 <customFields>{"application":"worker","environment":"local"}</customFields>
-                <mdcKeyFieldName>jobName</mdcKeyFieldName>
-                <mdcKeyFieldName>jobInstanceId</mdcKeyFieldName>
-                <mdcKeyFieldName>stepName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobName=jobName</mdcKeyFieldName>
+                <mdcKeyFieldName>jobInstanceId=jobInstanceId</mdcKeyFieldName>
+                <mdcKeyFieldName>stepName=stepName</mdcKeyFieldName>
                 <timestampPattern>yyyy-MM-dd'T'HH:mm:ss.SSS'Z'</timestampPattern>
                 <timeZone>UTC</timeZone>
             </encoder>


### PR DESCRIPTION
## 📝작업 내용
- worker `v0.0.9` 릴리즈 배포를 위한 변경사항 반영
- `logback-spring.xml`의 MDC key 매핑을 수정해 JSON 로그 필드가 기대한 형식으로 출력되도록 보완
- `docker-entrypoint.sh`에서 컨테이너 실행 인자가 애플리케이션으로 전달되도록 수정
- `release/HSC-265` 브랜치에 `hotfix/HSC-264` 머지 결과를 반영해 patch release 기준 정합성 확보

<br/>

## 👀변경 사항

| 구분 | 변경 파일/영역 | 변경 내용 | 기대 효과 |
|---|---|---|---|
| 로깅 | `src/main/resources/logback-spring.xml` | `mdcKeyFieldName`을 `key=value` 형식으로 수정해 `jobName`, `jobInstanceId`, `stepName`가 최상위 JSON 필드로 안정적으로 매핑되도록 보완 | Loki/Alloy 수집 및 로그 필드 쿼리 일관성 확보 |
| 컨테이너 실행 | `docker-entrypoint.sh` | `exec java -jar /app/app.jar "$@"`로 변경해 컨테이너 실행 시 전달한 추가 인자가 워커 애플리케이션까지 전달되도록 수정 | 운영/배치 실행 옵션 전달 안정성 향상 |
| 릴리즈 범위 | `release/HSC-265` | `hotfix/HSC-264` 머지 커밋을 포함한 `v0.0.9` patch release 범위 확정 | `v0.0.8` 이후 수정사항을 릴리즈 브랜치 기준으로 명확히 관리 |

<br/>

## 🎫 Jira Ticket
- Jira Ticket: HSC-265

<br/>

## #️⃣관련 이슈
- closes #26 