### PR TITLE
[HCR-305] 배치 오케스트레이션 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jdbc'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation platform('software.amazon.awssdk:bom:2.31.67')
+	implementation 'software.amazon.awssdk:athena'
 	implementation group: 'com.github.f4b6a3', name: 'tsid-creator', version: '5.2.6'
 	implementation 'org.springframework.kafka:spring-kafka'
     implementation 'software.amazon.msk:aws-msk-iam-auth:2.2.0'

--- a/src/main/java/site/holliverse/worker/BatchRunner.java
+++ b/src/main/java/site/holliverse/worker/BatchRunner.java
@@ -64,6 +64,11 @@ public class BatchRunner implements CommandLineRunner {
             params.addString("testStartTime", configuration.resolveTestStartTime());
         }
 
+        String snapshotDate = configuration.resolveSnapshotDate();
+        if (snapshotDate != null) {
+            params.addString("snapshotDate", snapshotDate);
+        }
+
         if (addRunId) {
             params.addLong("run.id", System.currentTimeMillis());
         }

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/AthenaFeatureSyncJobConfig.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/AthenaFeatureSyncJobConfig.java
@@ -1,0 +1,136 @@
+package site.holliverse.worker.batch.jobs.athena;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import site.holliverse.worker.batch.jobs.athena.tasklet.CleanupAthenaFeatureSyncTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.DeleteExistingSnapshotTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.GateAthenaFeatureSyncTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.ImportUserEventFeaturesTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.StartAthenaQueryTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.VerifyUserEventFeaturesTasklet;
+import site.holliverse.worker.batch.jobs.athena.tasklet.WaitAthenaCompletionTasklet;
+
+@Configuration
+@RequiredArgsConstructor
+public class AthenaFeatureSyncJobConfig {
+
+    public static final String JOB_NAME = "athenaFeatureSyncJob";
+
+    /**
+     * Athena feature 동기화 Job.
+     *
+     * 처리 흐름:
+     * 1) snapshotDate 확정
+     * 2) Athena 쿼리 실행
+     * 3) Athena 완료 대기 및 결과 S3 경로 획득
+     * 4) 동일 snapshotDate 기존 데이터 삭제
+     * 5) Athena 결과 CSV를 최종 테이블로 import
+     * 6) 적재 결과 검증
+     * 7) 실행 메타 로그 마무리
+     */
+    @Bean
+    public Job athenaFeatureSyncJob(
+            JobRepository jobRepository,
+            Step athenaFeatureSyncGateStep,
+            Step startAthenaQueryStep,
+            Step waitAthenaCompletionStep,
+            Step deleteExistingSnapshotStep,
+            Step importUserEventFeaturesStep,
+            Step verifyUserEventFeaturesStep,
+            Step cleanupAthenaFeatureSyncStep
+    ) {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(athenaFeatureSyncGateStep)
+                .next(startAthenaQueryStep)
+                .next(waitAthenaCompletionStep)
+                .next(deleteExistingSnapshotStep)
+                .next(importUserEventFeaturesStep)
+                .next(verifyUserEventFeaturesStep)
+                .next(cleanupAthenaFeatureSyncStep)
+                .build();
+    }
+
+    @Bean
+    public Step athenaFeatureSyncGateStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            GateAthenaFeatureSyncTasklet tasklet
+    ) {
+        return new StepBuilder("Step00_Gate", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step startAthenaQueryStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            StartAthenaQueryTasklet tasklet
+    ) {
+        return new StepBuilder("Step01_StartAthenaQuery", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step waitAthenaCompletionStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            WaitAthenaCompletionTasklet tasklet
+    ) {
+        return new StepBuilder("Step02_WaitAthenaCompletion", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step deleteExistingSnapshotStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            DeleteExistingSnapshotTasklet tasklet
+    ) {
+        return new StepBuilder("Step03_DeleteExistingSnapshot", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step importUserEventFeaturesStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            ImportUserEventFeaturesTasklet tasklet
+    ) {
+        return new StepBuilder("Step04_ImportUserEventFeatures", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step verifyUserEventFeaturesStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            VerifyUserEventFeaturesTasklet tasklet
+    ) {
+        return new StepBuilder("Step05_VerifyUserEventFeatures", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+
+    @Bean
+    public Step cleanupAthenaFeatureSyncStep(
+            JobRepository jobRepository,
+            PlatformTransactionManager tx,
+            CleanupAthenaFeatureSyncTasklet tasklet
+    ) {
+        return new StepBuilder("Step06_CleanupAthenaFeatureSync", jobRepository)
+                .tasklet(tasklet, tx)
+                .build();
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/repository/AthenaFeatureSyncRepository.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/repository/AthenaFeatureSyncRepository.java
@@ -1,0 +1,78 @@
+package site.holliverse.worker.batch.jobs.athena.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.stereotype.Repository;
+import site.holliverse.worker.batch.common.support.SqlFileLoader;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncProperties;
+
+@Repository
+@RequiredArgsConstructor
+public class AthenaFeatureSyncRepository {
+
+    private static final String DELETE_SQL_PATH = "sql/athena/delete_user_event_features_7d_snapshot.sql";
+    private static final String VERIFY_SQL_PATH = "sql/athena/verify_user_event_features_7d.sql";
+
+    private static final String TARGET_TABLE = "user_event_features_7d";
+    private static final String TARGET_COLUMNS = """
+            snapshot_date,
+            member_id,
+            click_list_type_cnt,
+            click_product_detail_cnt,
+            click_compare_cnt,
+            click_coupon_cnt,
+            click_penalty_cnt,
+            click_change_cnt,
+            click_change_success_cnt,
+            product_type_clicks,
+            product_type_top_tags
+            """;
+
+    private final NamedParameterJdbcTemplate namedParameterJdbcTemplate;
+    private final SqlFileLoader sqlFileLoader;
+    private final AthenaFeatureSyncProperties properties;
+
+    public int deleteBySnapshotDate(String snapshotDate) {
+        // 재실행 안전성을 위해 동일 snapshotDate 데이터를 먼저 제거한다.
+        String sql = sqlFileLoader.load(DELETE_SQL_PATH);
+        return namedParameterJdbcTemplate.update(sql, new MapSqlParameterSource("snapshotDate", snapshotDate));
+    }
+
+    public void importFromS3(String bucket, String key) {
+        // 최종 테이블에 직접 CSV를 적재한다.
+        // 컬럼 순서는 Athena 결과 CSV의 헤더와 동일해야 한다.
+        String sql = """
+                SELECT aws_s3.table_import_from_s3(
+                    '%s',
+                    '%s',
+                    '(format csv, header true)',
+                    aws_commons.create_s3_uri('%s', '%s', '%s')
+                )
+                """.formatted(
+                TARGET_TABLE,
+                TARGET_COLUMNS.replace("\r", "").replace("\n", " ").trim(),
+                escapeLiteral(bucket),
+                escapeLiteral(key),
+                escapeLiteral(properties.getAwsRegion())
+        );
+
+        namedParameterJdbcTemplate.getJdbcTemplate().execute(sql);
+    }
+
+    public long countBySnapshotDate(String snapshotDate) {
+        // 적재 결과가 최소 1건 이상인지 확인하는 검증용 조회다.
+        String sql = sqlFileLoader.load(VERIFY_SQL_PATH);
+        Long count = namedParameterJdbcTemplate.queryForObject(
+                sql,
+                new MapSqlParameterSource("snapshotDate", snapshotDate),
+                Long.class
+        );
+        return count == null ? 0L : count;
+    }
+
+    private String escapeLiteral(String value) {
+        // aws_commons.create_s3_uri 인자로 들어가는 문자열 literal escaping 용도다.
+        return value.replace("'", "''");
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/service/AthenaQueryService.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/service/AthenaQueryService.java
@@ -1,0 +1,104 @@
+package site.holliverse.worker.batch.jobs.athena.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncProperties;
+import software.amazon.awssdk.services.athena.AthenaClient;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.GetQueryExecutionResponse;
+import software.amazon.awssdk.services.athena.model.QueryExecutionContext;
+import software.amazon.awssdk.services.athena.model.QueryExecutionState;
+import software.amazon.awssdk.services.athena.model.ResultConfiguration;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionRequest;
+import software.amazon.awssdk.services.athena.model.StartQueryExecutionResponse;
+
+@Service
+@RequiredArgsConstructor
+public class AthenaQueryService {
+
+    private final AthenaClient athenaClient;
+    private final AthenaFeatureSyncProperties properties;
+
+    /**
+     * Athena 쿼리를 제출하고 queryExecutionId를 반환한다.
+     *
+     * 결과 저장 경로는 Athena 콘솔 기본값에 의존하지 않고
+     * 배치 설정의 outputLocation을 명시적으로 넣는다.
+     */
+    public String startQueryExecution(String sql) {
+        StartQueryExecutionRequest.Builder requestBuilder = StartQueryExecutionRequest.builder()
+                .queryString(sql)
+                .queryExecutionContext(QueryExecutionContext.builder()
+                        .database(properties.getDatabase())
+                        .build())
+                .resultConfiguration(ResultConfiguration.builder()
+                        .outputLocation(properties.getOutputLocation())
+                        .build());
+
+        if (properties.getWorkgroup() != null && !properties.getWorkgroup().isBlank()) {
+            requestBuilder.workGroup(properties.getWorkgroup());
+        }
+
+        StartQueryExecutionResponse response = athenaClient.startQueryExecution(requestBuilder.build());
+        return response.queryExecutionId();
+    }
+
+    /**
+     * Athena 실행이 끝날 때까지 polling 한다.
+     *
+     * 성공 시 Athena가 실제로 생성한 결과 CSV의 S3 경로를 반환한다.
+     * 실패나 취소 상태는 즉시 예외로 처리한다.
+     */
+    public String waitForSucceeded(String queryExecutionId) {
+        for (int i = 0; i < properties.getMaxPollCount(); i++) {
+            GetQueryExecutionResponse response = athenaClient.getQueryExecution(
+                    GetQueryExecutionRequest.builder()
+                            .queryExecutionId(queryExecutionId)
+                            .build()
+            );
+
+            var execution = response.queryExecution();
+            QueryExecutionState state = execution.status().state();
+
+            if (state == QueryExecutionState.SUCCEEDED) {
+                return execution.resultConfiguration().outputLocation();
+            }
+
+            if (state == QueryExecutionState.FAILED) {
+                throw new IllegalStateException(
+                        "Athena query failed. queryExecutionId=%s, reason=%s"
+                                .formatted(queryExecutionId, execution.status().stateChangeReason())
+                );
+            }
+
+            if (state == QueryExecutionState.CANCELLED) {
+                throw new IllegalStateException(
+                        "Athena query cancelled. queryExecutionId=%s".formatted(queryExecutionId)
+                );
+            }
+
+            if (state != QueryExecutionState.QUEUED && state != QueryExecutionState.RUNNING) {
+                throw new IllegalStateException(
+                        "Unexpected Athena state. queryExecutionId=%s, state=%s"
+                                .formatted(queryExecutionId, state)
+                );
+            }
+
+            sleep(properties.getPollIntervalMillis());
+        }
+
+        throw new IllegalStateException(
+                "Athena query polling timeout. queryExecutionId=%s".formatted(queryExecutionId)
+        );
+    }
+
+    private void sleep(long millis) {
+        // Athena 완료 polling은 짧은 간격으로 반복되므로 인터럽트 상태를 복구해주는 게 중요하다.
+        try {
+            Thread.sleep(millis);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Thread interrupted while polling Athena", e);
+        }
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaFeatureSyncContextKeys.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaFeatureSyncContextKeys.java
@@ -1,0 +1,32 @@
+package site.holliverse.worker.batch.jobs.athena.support;
+
+/**
+ * Athena feature sync Job이 ExecutionContext에 저장하는 key 모음.
+ *
+ * ExecutionContext는 Step 간에 값을 전달하는 공유 저장소다.
+ * 이 Job에서는 Athena 실행 결과와 snapshotDate를 여러 Step이 순차적으로 재사용하므로
+ * 문자열 상수를 한 곳에 모아 오타와 중복을 줄인다.
+ */
+public final class AthenaFeatureSyncContextKeys {
+
+    private AthenaFeatureSyncContextKeys() {
+    }
+
+    // 배치 실행 기준 날짜. Gate Step에서 확정한 뒤 이후 모든 Step이 사용한다.
+    public static final String SNAPSHOT_DATE = "snapshotDate";
+
+    // Athena StartQueryExecution 호출 후 즉시 반환되는 실행 ID.
+    public static final String QUERY_EXECUTION_ID = "queryExecutionId";
+
+    // Athena가 성공적으로 생성한 결과 CSV의 전체 S3 URI.
+    public static final String OUTPUT_LOCATION = "outputLocation";
+
+    // OUTPUT_LOCATION에서 추출한 S3 bucket 이름.
+    public static final String OUTPUT_BUCKET = "outputBucket";
+
+    // OUTPUT_LOCATION에서 추출한 S3 object key.
+    public static final String OUTPUT_KEY = "outputKey";
+
+    // 최종 검증 단계에서 계산한 적재 건수.
+    public static final String IMPORTED_ROW_COUNT = "importedRowCount";
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaFeatureSyncProperties.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaFeatureSyncProperties.java
@@ -1,0 +1,86 @@
+package site.holliverse.worker.batch.jobs.athena.support;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Athena feature sync Job 전용 설정 묶음.
+ *
+ * application.worker.yml 의
+ * worker.job.athena-feature-sync.* 값을 이 객체로 자동 매핑한다.
+ *
+ * 예:
+ * - aws-region -> awsRegion
+ * - output-location -> outputLocation
+ * - max-poll-count -> maxPollCount
+ */
+@Configuration
+@ConfigurationProperties(prefix = "worker.job.athena-feature-sync")
+public class AthenaFeatureSyncProperties {
+
+    // Athena와 S3가 동작하는 AWS 리전. 현재 기본값은 서울 리전이다.
+    private String awsRegion = "ap-northeast-2";
+
+    // Athena 쿼리를 실행할 database 이름.
+    private String database = "holliverse_analytics";
+
+    // Athena Workgroup 이름. 비워두면 request에 workgroup을 넣지 않는다.
+    private String workgroup;
+
+    // Athena 결과 CSV 저장 prefix. raw 로그 LOCATION과는 다른 값이다.
+    private String outputLocation;
+
+    // Athena 완료 polling 간격(ms).
+    private long pollIntervalMillis = 5000L;
+
+    // Athena polling 최대 횟수. 사실상 timeout 역할을 한다.
+    private int maxPollCount = 120;
+
+    public String getAwsRegion() {
+        return awsRegion;
+    }
+
+    public void setAwsRegion(String awsRegion) {
+        this.awsRegion = awsRegion;
+    }
+
+    public String getDatabase() {
+        return database;
+    }
+
+    public void setDatabase(String database) {
+        this.database = database;
+    }
+
+    public String getWorkgroup() {
+        return workgroup;
+    }
+
+    public void setWorkgroup(String workgroup) {
+        this.workgroup = workgroup;
+    }
+
+    public String getOutputLocation() {
+        return outputLocation;
+    }
+
+    public void setOutputLocation(String outputLocation) {
+        this.outputLocation = outputLocation;
+    }
+
+    public long getPollIntervalMillis() {
+        return pollIntervalMillis;
+    }
+
+    public void setPollIntervalMillis(long pollIntervalMillis) {
+        this.pollIntervalMillis = pollIntervalMillis;
+    }
+
+    public int getMaxPollCount() {
+        return maxPollCount;
+    }
+
+    public void setMaxPollCount(int maxPollCount) {
+        this.maxPollCount = maxPollCount;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaSqlTemplateFactory.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AthenaSqlTemplateFactory.java
@@ -1,0 +1,29 @@
+package site.holliverse.worker.batch.jobs.athena.support;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.common.support.SqlFileLoader;
+
+/**
+ * Athena SQL 템플릿 로딩 및 snapshotDate 바인딩 담당 클래스.
+ *
+ * SQL 파일 경로와 템플릿 처리 책임을 Tasklet에서 분리해
+ * Step 로직은 "언제 실행할지"에만 집중하고,
+ * 이 클래스는 "어떤 SQL을 만들지"를 담당하도록 나눈다.
+ */
+@Component
+@RequiredArgsConstructor
+public class AthenaSqlTemplateFactory {
+
+    // 현재 user_event_features_7d 적재용 Athena 집계 쿼리 위치.
+    private static final String SQL_PATH = "sql/athena/user_event_features_7d.sql";
+
+    private final SqlFileLoader sqlFileLoader;
+
+    public String buildUserEventFeaturesQuery(String snapshotDate) {
+        // SQL 템플릿은 리소스 파일로 관리하고
+        // 실행 시점에는 snapshotDate만 주입해 최종 쿼리를 만든다.
+        String template = sqlFileLoader.load(SQL_PATH);
+        return template.formatted(snapshotDate);
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AwsAthenaConfig.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/AwsAthenaConfig.java
@@ -1,0 +1,24 @@
+package site.holliverse.worker.batch.jobs.athena.support;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.athena.AthenaClient;
+
+/**
+ * Athena SDK Client bean 설정.
+ *
+ * Spring 컨테이너가 AthenaClient를 한 번 생성해 재사용하도록 등록한다.
+ * 리전은 AthenaFeatureSyncProperties에서 읽는다.
+ */
+@Configuration
+public class AwsAthenaConfig {
+
+    @Bean
+    public AthenaClient athenaClient(AthenaFeatureSyncProperties properties) {
+        // Athena는 리전 정보가 필수다. 현재 기본값은 서울 리전(ap-northeast-2)이다.
+        return AthenaClient.builder()
+                .region(Region.of(properties.getAwsRegion()))
+                .build();
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/S3OutputLocationParser.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/S3OutputLocationParser.java
@@ -1,0 +1,43 @@
+package site.holliverse.worker.batch.jobs.athena.support;
+
+import org.springframework.stereotype.Component;
+
+/**
+ * Athena OutputLocation 문자열을 bucket / key로 분리하는 도우미.
+ *
+ * Athena는 결과 파일 경로를 s3://bucket/key 형식 문자열 하나로 돌려준다.
+ * 반면 PostgreSQL aws_s3.table_import_from_s3는 bucket, key, region을 따로 받으므로
+ * import 직전에 이 파싱 단계가 필요하다.
+ */
+@Component
+public class S3OutputLocationParser {
+
+    public ParsedS3Path parse(String s3Uri) {
+        // Athena 결과 경로는 항상 s3:// 로 시작해야 한다.
+        if (s3Uri == null || !s3Uri.startsWith("s3://")) {
+            throw new IllegalArgumentException("Invalid S3 URI: " + s3Uri);
+        }
+
+        String withoutScheme = s3Uri.substring("s3://".length());
+        int firstSlash = withoutScheme.indexOf('/');
+
+        if (firstSlash < 0) {
+            return new ParsedS3Path(withoutScheme, "");
+        }
+
+        String bucket = withoutScheme.substring(0, firstSlash);
+        String key = withoutScheme.substring(firstSlash + 1);
+
+        return new ParsedS3Path(bucket, key);
+    }
+
+    /**
+     * 파싱 결과를 담는 단순 record.
+     *
+     * 예:
+     * - bucket: holliverse-log
+     * - key: athena-results/feature-sync/uuid.csv
+     */
+    public record ParsedS3Path(String bucket, String key) {
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/support/S3OutputLocationParser.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/support/S3OutputLocationParser.java
@@ -19,7 +19,15 @@ public class S3OutputLocationParser {
         }
 
         String withoutScheme = s3Uri.substring("s3://".length());
+        if (withoutScheme.isBlank()) {
+            throw new IllegalArgumentException("Invalid S3 URI: " + s3Uri);
+        }
+
         int firstSlash = withoutScheme.indexOf('/');
+
+        if (firstSlash == 0) {
+            throw new IllegalArgumentException("Invalid S3 URI: " + s3Uri);
+        }
 
         if (firstSlash < 0) {
             return new ParsedS3Path(withoutScheme, "");

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/CleanupAthenaFeatureSyncTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/CleanupAthenaFeatureSyncTasklet.java
@@ -1,0 +1,33 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+
+@Component
+@Slf4j
+public class CleanupAthenaFeatureSyncTasklet implements Tasklet {
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        // 현재는 별도 정리 작업보다는 실행 메타 정보를 한 번에 남기는 역할만 수행한다.
+        // 나중에 Athena 실행 로그 테이블이나 알림 연동이 필요하면 이 Step을 확장하면 된다.
+        var executionContext = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        log.info(
+                "Athena feature sync completed. snapshotDate={}, queryExecutionId={}, outputLocation={}, importedRowCount={}",
+                executionContext.getString(AthenaFeatureSyncContextKeys.SNAPSHOT_DATE),
+                executionContext.getString(AthenaFeatureSyncContextKeys.QUERY_EXECUTION_ID),
+                executionContext.getString(AthenaFeatureSyncContextKeys.OUTPUT_LOCATION),
+                executionContext.getLong(AthenaFeatureSyncContextKeys.IMPORTED_ROW_COUNT, 0L)
+        );
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/DeleteExistingSnapshotTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/DeleteExistingSnapshotTasklet.java
@@ -1,0 +1,34 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.repository.AthenaFeatureSyncRepository;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DeleteExistingSnapshotTasklet implements Tasklet {
+
+    private final AthenaFeatureSyncRepository repository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        // 현재 구현은 staging 없이 최종 테이블에 바로 적재한다.
+        // 같은 snapshotDate로 재실행될 수 있으므로 먼저 기존 데이터를 정리한다.
+        String snapshotDate = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext()
+                .getString(AthenaFeatureSyncContextKeys.SNAPSHOT_DATE);
+
+        int deleted = repository.deleteBySnapshotDate(snapshotDate);
+        log.info("Existing snapshot rows deleted. snapshotDate={}, deleted={}", snapshotDate, deleted);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/GateAthenaFeatureSyncTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/GateAthenaFeatureSyncTasklet.java
@@ -1,0 +1,88 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncProperties;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.format.DateTimeParseException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class GateAthenaFeatureSyncTasklet implements Tasklet {
+
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+    private final JdbcTemplate jdbcTemplate;
+    private final AthenaFeatureSyncProperties properties;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        // 외부에서 받은 snapshotDate 파라미터를 읽는다.
+        // 값이 없으면 기본적으로 KST 오늘 날짜를 사용한다.
+        String snapshotDateParam = (String) chunkContext.getStepContext()
+                .getJobParameters()
+                .get("snapshotDate");
+
+        LocalDate snapshotDate = resolveSnapshotDate(snapshotDateParam);
+        // Job 시작 전에 필수 설정과 대상 테이블 존재 여부를 확인한다.
+        validateInfrastructure();
+        verifyRequiredTable();
+
+        // 다음 Step들이 공통으로 사용할 수 있게 ExecutionContext에 저장한다.
+        chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext()
+                .putString(AthenaFeatureSyncContextKeys.SNAPSHOT_DATE, snapshotDate.toString());
+
+        log.info("Athena feature sync gate passed. snapshotDate={}", snapshotDate);
+        return RepeatStatus.FINISHED;
+    }
+
+    private LocalDate resolveSnapshotDate(String snapshotDateParam) {
+        // snapshotDate가 없으면 스케줄 배치가 바로 돌 수 있도록 오늘 날짜를 기본값으로 사용한다.
+        if (snapshotDateParam == null || snapshotDateParam.isBlank()) {
+            return LocalDate.now(KST);
+        }
+
+        try {
+            return LocalDate.parse(snapshotDateParam);
+        } catch (DateTimeParseException e) {
+            throw new IllegalArgumentException(
+                    "snapshotDate format is invalid. expected yyyy-MM-dd",
+                    e
+            );
+        }
+    }
+
+    private void validateInfrastructure() {
+        // Athena 결과 CSV 저장 경로는 필수다.
+        // 이 값이 없으면 Athena는 쿼리 결과를 어디에 저장할지 결정할 수 없다.
+        if (properties.getOutputLocation() == null || properties.getOutputLocation().isBlank()) {
+            throw new IllegalStateException("worker.job.athena-feature-sync.output-location is required");
+        }
+    }
+
+    private void verifyRequiredTable() {
+        // 최종 적재 대상 테이블이 없는 상태로 Job이 시작되면 import 단계에서 실패하므로 초기에 검증한다.
+        String regClass = jdbcTemplate.queryForObject(
+                "select to_regclass(?)",
+                String.class,
+                "user_event_features_7d"
+        );
+
+        if (regClass == null) {
+            throw new IllegalStateException("Required table does not exist: user_event_features_7d");
+        }
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/ImportUserEventFeaturesTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/ImportUserEventFeaturesTasklet.java
@@ -1,0 +1,39 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.repository.AthenaFeatureSyncRepository;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ImportUserEventFeaturesTasklet implements Tasklet {
+
+    private final AthenaFeatureSyncRepository repository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        var executionContext = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        // Athena가 실제로 생성한 결과 CSV의 bucket/key를 사용한다.
+        // 파일명을 추측하지 않고 OutputLocation을 그대로 신뢰하는 방식이다.
+        String bucket = executionContext.getString(AthenaFeatureSyncContextKeys.OUTPUT_BUCKET);
+        String key = executionContext.getString(AthenaFeatureSyncContextKeys.OUTPUT_KEY);
+
+        // PostgreSQL aws_s3 확장을 통해 RDS가 S3에서 직접 CSV를 읽는다.
+        // 배치 애플리케이션이 파일 내용을 중간에서 내려받아 전달하지 않는다.
+        repository.importFromS3(bucket, key);
+
+        log.info("Imported Athena output into user_event_features_7d. bucket={}, key={}", bucket, key);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/StartAthenaQueryTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/StartAthenaQueryTasklet.java
@@ -1,0 +1,42 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.service.AthenaQueryService;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaSqlTemplateFactory;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class StartAthenaQueryTasklet implements Tasklet {
+
+    private final AthenaQueryService athenaQueryService;
+    private final AthenaSqlTemplateFactory athenaSqlTemplateFactory;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        var executionContext = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        // Gate Step에서 확정한 snapshotDate를 기준으로 Athena SQL을 만든다.
+        String snapshotDate = executionContext.getString(AthenaFeatureSyncContextKeys.SNAPSHOT_DATE);
+        String sql = athenaSqlTemplateFactory.buildUserEventFeaturesQuery(snapshotDate);
+
+        // Athena에 쿼리를 제출하면 즉시 queryExecutionId를 받는다.
+        // 실제 결과 파일 경로는 아직 모르고, 다음 Step에서 완료 polling 후 획득한다.
+        String queryExecutionId = athenaQueryService.startQueryExecution(sql);
+
+        executionContext.putString(AthenaFeatureSyncContextKeys.QUERY_EXECUTION_ID, queryExecutionId);
+
+        log.info("Athena query submitted. snapshotDate={}, queryExecutionId={}", snapshotDate, queryExecutionId);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/VerifyUserEventFeaturesTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/VerifyUserEventFeaturesTasklet.java
@@ -1,0 +1,41 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.repository.AthenaFeatureSyncRepository;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VerifyUserEventFeaturesTasklet implements Tasklet {
+
+    private final AthenaFeatureSyncRepository repository;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        var executionContext = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        // 적재가 끝난 뒤 해당 snapshotDate 데이터가 실제로 들어갔는지 최소 검증을 수행한다.
+        String snapshotDate = executionContext.getString(AthenaFeatureSyncContextKeys.SNAPSHOT_DATE);
+        long rowCount = repository.countBySnapshotDate(snapshotDate);
+
+        if (rowCount <= 0) {
+            throw new IllegalStateException("Imported row count is zero. snapshotDate=" + snapshotDate);
+        }
+
+        // 마지막 Step 로그에서 사용할 수 있도록 적재 건수를 남긴다.
+        executionContext.putLong(AthenaFeatureSyncContextKeys.IMPORTED_ROW_COUNT, rowCount);
+
+        log.info("Verified imported rows. snapshotDate={}, rowCount={}", snapshotDate, rowCount);
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/WaitAthenaCompletionTasklet.java
+++ b/src/main/java/site/holliverse/worker/batch/jobs/athena/tasklet/WaitAthenaCompletionTasklet.java
@@ -1,0 +1,49 @@
+package site.holliverse.worker.batch.jobs.athena.tasklet;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.batch.core.StepContribution;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.repeat.RepeatStatus;
+import org.springframework.stereotype.Component;
+import site.holliverse.worker.batch.jobs.athena.service.AthenaQueryService;
+import site.holliverse.worker.batch.jobs.athena.support.AthenaFeatureSyncContextKeys;
+import site.holliverse.worker.batch.jobs.athena.support.S3OutputLocationParser;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class WaitAthenaCompletionTasklet implements Tasklet {
+
+    private final AthenaQueryService athenaQueryService;
+    private final S3OutputLocationParser s3OutputLocationParser;
+
+    @Override
+    public RepeatStatus execute(StepContribution contribution, ChunkContext chunkContext) {
+        var executionContext = chunkContext.getStepContext()
+                .getStepExecution()
+                .getJobExecution()
+                .getExecutionContext();
+
+        // 이전 Step에서 저장한 queryExecutionId로 Athena 실행 상태를 조회한다.
+        String queryExecutionId = executionContext.getString(AthenaFeatureSyncContextKeys.QUERY_EXECUTION_ID);
+
+        // Athena가 성공하면 결과 CSV의 전체 S3 경로를 반환한다.
+        String outputLocation = athenaQueryService.waitForSucceeded(queryExecutionId);
+
+        // 이후 RDS import에서 bucket/key가 필요하므로 S3 URI를 분해해 함께 저장한다.
+        S3OutputLocationParser.ParsedS3Path parsed = s3OutputLocationParser.parse(outputLocation);
+
+        executionContext.putString(AthenaFeatureSyncContextKeys.OUTPUT_LOCATION, outputLocation);
+        executionContext.putString(AthenaFeatureSyncContextKeys.OUTPUT_BUCKET, parsed.bucket());
+        executionContext.putString(AthenaFeatureSyncContextKeys.OUTPUT_KEY, parsed.key());
+
+        log.info(
+                "Athena query succeeded. queryExecutionId={}, outputLocation={}",
+                queryExecutionId,
+                outputLocation
+        );
+        return RepeatStatus.FINISHED;
+    }
+}

--- a/src/main/java/site/holliverse/worker/config/BatchJobConfiguration.java
+++ b/src/main/java/site/holliverse/worker/config/BatchJobConfiguration.java
@@ -22,6 +22,9 @@ public class BatchJobConfiguration {
     @Value("${BATCH_TEST_START_TIME:${spring.batch.testJob.startTime:}}")
     private String testJobStartTime;
 
+    @Value("${SNAPSHOT_DATE:${BATCH_SNAPSHOT_DATE:${spring.batch.job.snapshotDate:}}}")
+    private String snapshotDate;
+
     private final ObjectMapper mapper;
 
     @PostConstruct
@@ -29,6 +32,7 @@ public class BatchJobConfiguration {
         log.info("========= Batch Configuration =========");
         log.info("jobName: '{}'", jobName);
         log.info("job1StartTime: '{}'", testJobStartTime);
+        log.info("snapshotDate: '{}'", snapshotDate);
         log.info("=======================================");
     }
 
@@ -40,5 +44,12 @@ public class BatchJobConfiguration {
             return Instant.now().toString();
         }
         return Instant.parse(testJobStartTime).toString();
+    }
+
+    public String resolveSnapshotDate() {
+        if (snapshotDate == null || snapshotDate.isBlank()) {
+            return null;
+        }
+        return snapshotDate;
     }
 }

--- a/src/main/resources/application.worker.yml
+++ b/src/main/resources/application.worker.yml
@@ -6,12 +6,14 @@ worker:
     tsid-node: ${TSID_NODE:0}
   logging:
     json-file-path: ${WORKER_LOG_JSON_FILE_PATH:./logs/worker.json}
-  kafka:
-    topic:
-      analysis-request: ${ANALYSIS_REQUEST_TOPIC:analysis.request.v1}
-    outbox:
-      max-attempts: ${ANALYSIS_DISPATCH_MAX_ATTEMPTS:3}
   job:
+    athena-feature-sync:
+      aws-region: ${ATHENA_FEATURE_SYNC_AWS_REGION:ap-northeast-2}
+      database: ${ATHENA_FEATURE_SYNC_DATABASE:holliverse_analytics}
+      workgroup: ${ATHENA_FEATURE_SYNC_WORKGROUP:}
+      output-location: ${ATHENA_FEATURE_SYNC_OUTPUT_LOCATION:}
+      poll-interval-millis: ${ATHENA_FEATURE_SYNC_POLL_INTERVAL_MILLIS:5000}
+      max-poll-count: ${ATHENA_FEATURE_SYNC_MAX_POLL_COUNT:120}
     consultation-analysis:
       #AWS ECR counselling-analytics image version
       analyzer-version: ${ANALYZER_VERSION:1}
@@ -21,6 +23,11 @@ worker:
       claim-lease-sec: ${ANALYSIS_CLAIM_LEASE_TTL:1800}
       #alias dictionary
       alias-dictionary-path: ${ANALYSIS_ALIAS_DICTIONARY_PATH:/efs/analysis/alias-dictionary.json}
+  kafka:
+    topic:
+      analysis-request: ${ANALYSIS_REQUEST_TOPIC:analysis.request.v1}
+    outbox:
+      max-attempts: ${ANALYSIS_DISPATCH_MAX_ATTEMPTS:3}
 
 ########################################
 # Spring Batch setting

--- a/src/main/resources/sql/athena/delete_user_event_features_7d_snapshot.sql
+++ b/src/main/resources/sql/athena/delete_user_event_features_7d_snapshot.sql
@@ -1,0 +1,2 @@
+DELETE FROM user_event_features_7d
+WHERE snapshot_date = CAST(:snapshotDate AS date)

--- a/src/main/resources/sql/athena/user_event_features_7d.sql
+++ b/src/main/resources/sql/athena/user_event_features_7d.sql
@@ -1,0 +1,116 @@
+WITH params AS (
+    SELECT DATE('%s') AS snapshot_date
+),
+base AS (
+    SELECT
+        p.snapshot_date,
+        r.member_id,
+        r.event_name,
+        CAST(SUBSTR(r."timestamp", 1, 10) AS DATE) AS event_date,
+        UPPER(r.event_properties.product_type) AS product_type,
+        r.event_properties.tags AS tags
+    FROM holliverse_analytics.customer_event_logs_raw r
+    CROSS JOIN params p
+    WHERE CAST(r.dt AS DATE)
+          BETWEEN date_add('day', -89, p.snapshot_date) AND p.snapshot_date
+),
+counts AS (
+    SELECT
+        snapshot_date,
+        member_id,
+        SUM(CASE WHEN event_name = 'click_list_type'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_list_type_cnt,
+        SUM(CASE WHEN event_name = 'click_product_detail'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_product_detail_cnt,
+        SUM(CASE WHEN event_name = 'click_compare'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_compare_cnt,
+        SUM(CASE WHEN event_name = 'click_coupon'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_coupon_cnt,
+        SUM(CASE WHEN event_name = 'click_penalty'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_penalty_cnt,
+        SUM(CASE WHEN event_name = 'click_change'
+                  AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_change_cnt,
+        SUM(CASE WHEN event_name = 'click_change_success'
+                  AND event_date BETWEEN date_add('day', -89, snapshot_date) AND snapshot_date
+                 THEN 1 ELSE 0 END) AS click_change_success_cnt
+    FROM base
+    GROUP BY 1, 2
+),
+product_type_counts AS (
+    SELECT
+        snapshot_date,
+        member_id,
+        json_format(CAST(map_agg(product_type, cnt) AS JSON)) AS product_type_clicks
+    FROM (
+        SELECT
+            snapshot_date,
+            member_id,
+            product_type,
+            COUNT(*) AS cnt
+        FROM base
+        WHERE product_type IS NOT NULL
+          AND event_date BETWEEN date_add('day', -6, snapshot_date) AND snapshot_date
+        GROUP BY 1, 2, 3
+    ) t
+    GROUP BY 1, 2
+),
+product_type_tag_counts AS (
+    SELECT
+        b.snapshot_date,
+        b.member_id,
+        tag,
+        COUNT(*) AS tag_cnt
+    FROM base b
+    CROSS JOIN UNNEST(b.tags) AS u(tag)
+    WHERE b.event_name = 'click_product_detail'
+      AND b.tags IS NOT NULL
+      AND b.event_date BETWEEN date_add('day', -6, b.snapshot_date) AND b.snapshot_date
+    GROUP BY 1, 2, 3
+),
+ranked_product_type_tags AS (
+    SELECT
+        snapshot_date,
+        member_id,
+        tag,
+        tag_cnt,
+        row_number() OVER (
+            PARTITION BY snapshot_date, member_id
+            ORDER BY tag_cnt DESC, tag ASC
+        ) AS rn
+    FROM product_type_tag_counts
+),
+product_type_top_tags AS (
+    SELECT
+        snapshot_date,
+        member_id,
+        json_format(CAST(array_agg(tag ORDER BY tag_cnt DESC, tag ASC) AS JSON)) AS product_type_top_tags
+    FROM ranked_product_type_tags
+    WHERE rn <= 3
+    GROUP BY 1, 2
+)
+SELECT
+    c.snapshot_date,
+    c.member_id,
+    c.click_list_type_cnt,
+    c.click_product_detail_cnt,
+    c.click_compare_cnt,
+    c.click_coupon_cnt,
+    c.click_penalty_cnt,
+    c.click_change_cnt,
+    c.click_change_success_cnt,
+    COALESCE(ptc.product_type_clicks, '{}') AS product_type_clicks,
+    COALESCE(ptt.product_type_top_tags, '[]') AS product_type_top_tags
+FROM counts c
+LEFT JOIN product_type_counts ptc
+    ON c.snapshot_date = ptc.snapshot_date
+   AND c.member_id = ptc.member_id
+LEFT JOIN product_type_top_tags ptt
+    ON c.snapshot_date = ptt.snapshot_date
+   AND c.member_id = ptt.member_id
+ORDER BY c.member_id

--- a/src/main/resources/sql/athena/verify_user_event_features_7d.sql
+++ b/src/main/resources/sql/athena/verify_user_event_features_7d.sql
@@ -1,0 +1,3 @@
+SELECT COUNT(*)
+FROM user_event_features_7d
+WHERE snapshot_date = CAST(:snapshotDate AS date)


### PR DESCRIPTION
## 📝작업 내용
<!-- 작업한 내용들 명시 -->

스프링 배치 오케스트레이션 코드 작성

aws s3-> athena - > rds 에 적재하는 과정을 스프링배치로 실행합니다.

<br/>

## 👀변경 사항
<!-- 팀원들이 알아야할 코드 , 설정, 구조등 변경을 명시 -->

| 구분 | 변경 내용 | 비고 |                                                                                                                                               
  | --- | --- | --- |                                                                                                                                                       
  | 신규 배치 Job | athenaFeatureSyncJob 추가 | Athena 실행 -> 완료 대기 -> 삭제 -> import -> 검증 |                                                                        
  | Step 구성 | Gate, StartAthenaQuery, WaitAthenaCompletion, DeleteExistingSnapshot, ImportUserEventFeatures, VerifyUserEventFeatures, Cleanup 추가 | 단일 테이블 직적재 흐름 |                                                                                                                                                                      
  | Athena 연동 | AWS SDK 기반 StartQueryExecution, GetQueryExecution 구현 | OutputLocation 기반 처리 |                                                                     
  | S3 결과 처리 | Athena 결과 S3 URI를 bucket/key로 파싱 | 파일명 추측 없이 실제 반환값 사용 |                                                                             
  | DB 적재 전략 | user_event_features_7d 대상 delete + import 적용 | staging 없이 최종 테이블 직적재 |
  | SQL 분리 | Athena 집계 쿼리, 삭제 SQL, 검증 SQL 리소스 추가 | src/main/resources/sql/athena |                                                                           
  | 설정 추가 | Athena region/database/workgroup/output-location/polling 설정 추가 | application.worker.yml |                                                               
  | 파라미터 처리 | SNAPSHOT_DATE를 snapshotDate JobParameter로 전달하도록 연결 | 기존 잡 방식과 맞춤 |                                                                     
  | 지원 클래스 추가 | Properties, ContextKeys, SQL Template Factory, S3 Parser, Athena Client Config 추가 | Athena 배치 공통 로직 분리 |                                   
  | 문서화 | Athena 초기 설정, 코드 흐름, 운영 체크리스트 문서 추가 | docs/private/athena |                                                                                 
  | 주석 보강 | Athena 배치 코드와 support 패키지에 한글 주석 추가 | 유지보수성 강화 |                                                                                      
  | 검증 | .\gradlew.bat compileJava --no-daemon 통과 | 컴파일 기준 확인 완료 |

<br/>

## 🎫 Jira Ticket
- Jira Ticket: HCR-305

<br/>

## #️⃣관련 이슈

- closes #35  
